### PR TITLE
Remove requiresConfsig

### DIFF
--- a/packages/chamber-contracts/migrations/2_deploy_contracts.js
+++ b/packages/chamber-contracts/migrations/2_deploy_contracts.js
@@ -43,6 +43,7 @@ module.exports = (deployer) => {
   })
   .then(() => deployer.deploy(
     RootChain,
+    VerifierUtil.address,
     CustomVerifier.address,
     ERC721.address,
     Checkpoint.address

--- a/packages/chamber-contracts/test/Checkpoint.test.js
+++ b/packages/chamber-contracts/test/Checkpoint.test.js
@@ -74,6 +74,7 @@ contract("Checkpoint", ([alice, bob, operator, user4, user5, admin]) => {
     await this.customVerifier.addVerifier(this.standardVerifier.address, {from: operator})
     await this.customVerifier.addVerifier(this.swapVerifier.address, {from: operator})
     this.rootChain = await RootChain.new(
+      this.verifierUtil.address,
       this.customVerifier.address,
       this.erc721.address,
       this.checkpoint.address,

--- a/packages/chamber-contracts/test/FastFinality.test.js
+++ b/packages/chamber-contracts/test/FastFinality.test.js
@@ -64,6 +64,7 @@ contract("FastFinality", ([alice, bob, operator, merchant, user5, admin]) => {
     await this.customVerifier.addVerifier(this.standardVerifier.address, {from: operator})
     await this.customVerifier.addVerifier(this.swapVerifier.address, {from: operator})
     this.rootChain = await RootChain.new(
+      this.verifierUtil.address,
       this.customVerifier.address,
       this.erc721.address,
       this.checkpoint.address,

--- a/packages/chamber-contracts/test/Rootchain.test.js
+++ b/packages/chamber-contracts/test/Rootchain.test.js
@@ -68,6 +68,7 @@ contract("RootChain", ([alice, bob, operator, user4, user5, admin]) => {
         from: operator
       })
     this.rootChain = await RootChain.new(
+      this.verifierUtil.address,
       this.customVerifier.address,
       this.erc721.address,
       this.checkpoint.address,


### PR DESCRIPTION
transaction verifier should have flag of confsig.
if true the tx require confusing for exit game.
User who sign this tx should confirm this flag is true or false.
Some kind of transactions isn't safe without confirmation signature.

on the other hands, if malicious developer add new transaction which has 2 inputs without confsig flag.
And they use this tx as challenge. They can make exit's priority high invalidity.

tx1->tx2 (tx2 is new custom transaction)

In almost case, tx2 require the signature of tx1's owner, so it's not problem. But in some case it's problem, for example, tx2 is reveal tx(reveal tx require presage of has not signature).

Correct implementation is that if tx2 has multiple inputs(getSpentEvidence return multiple evidences) tx2 should require confsig. we shouldn't use flag.
